### PR TITLE
Search: three switches (scope, granularity, matching), plus paging/sorting fixes

### DIFF
--- a/backend/src/migrations/001_search_switches.sql
+++ b/backend/src/migrations/001_search_switches.sql
@@ -1,0 +1,62 @@
+-- 001_search_switches.sql
+-- Adds the DB support for the three search switches:
+--   Corrispondenza  Esatta / Varianti
+--   Granularita     Parola intera / Stringa   (only under Esatta)
+--   Ambito          Solo titolo / Tutto il testo
+--
+-- Idempotent: safe to re-run. Runs in one transaction, so a failure leaves
+-- the database untouched.
+--
+-- Must run as the owner of the editions table. Despite the ALTER SCHEMA in
+-- setup_db.sql, the live table is owned by isagog, not copertine_app, so
+-- the ALTER TABLE below needs that role:
+--
+--   docker exec -i mema-postgres \
+--     psql -U isagog -d copertine -v ON_ERROR_STOP=1 \
+--     < backend/src/migrations/001_search_switches.sql
+--
+-- cop_norm() is left with the default PUBLIC execute grant, so the
+-- application role copertine_app can call it without an extra GRANT.
+
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-----------------------------------------------------------
+-- 1. Normalizer used by the two literal ("Esatta") modes
+-----------------------------------------------------------
+-- Folds the three differences that made literal search miss obvious hits:
+--   * case            -> lower()
+--   * accents         -> unaccent(), so "perche" finds "Perche' no"
+--   * apostrophes     -> the corpus mixes ASCII ' (468 rows) with the
+--                        typographic U+2019 (41 rows); both become ASCII
+--
+-- The two-argument unaccent() form is IMMUTABLE (the one-argument form is
+-- only STABLE), which is what lets this function be IMMUTABLE and therefore
+-- inlinable by the planner and usable in an expression index later on.
+--
+-- No SET search_path clause on purpose: it would block inlining. unaccent
+-- lives in public, which is on the default search_path for this database.
+CREATE OR REPLACE FUNCTION cop_norm(t text) RETURNS text
+    LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE AS
+$$ SELECT lower(unaccent('unaccent', regexp_replace(t, '[’‘´`]', '''', 'g'))) $$;
+
+COMMENT ON FUNCTION cop_norm(text) IS
+    'Case/accent/apostrophe folding for literal search (Esatta modes).';
+
+-----------------------------------------------------------
+-- 2. Title-only search vector ("Solo titolo" under Varianti)
+-----------------------------------------------------------
+-- editions.search_vector already covers caption (weight A) + kicker (weight B)
+-- as one blob, so it cannot answer a title-only query: a kicker hit would
+-- still satisfy @@. This second vector indexes the caption alone.
+ALTER TABLE editions
+    ADD COLUMN IF NOT EXISTS caption_vector tsvector
+    GENERATED ALWAYS AS (
+        to_tsvector('italian_unaccent', coalesce(caption, ''))
+    ) STORED;
+
+CREATE INDEX IF NOT EXISTS idx_editions_caption_search
+    ON editions USING GIN (caption_vector);
+
+COMMIT;

--- a/backend/src/setup_db.sql
+++ b/backend/src/setup_db.sql
@@ -39,7 +39,23 @@ ALTER TEXT SEARCH CONFIGURATION italian_unaccent
     WITH unaccent, italian_stem;
 
 -----------------------------------------------------------
--- 5. Editions table
+-- 5. Normalizer for literal ("Esatta") search
+-----------------------------------------------------------
+-- Folds case, accents and the two apostrophe forms the corpus mixes, so
+-- "perche" finds "Perche' no" and "c'e" finds "nell(U+2019)emergenza".
+-- The two-argument unaccent() form is IMMUTABLE (the one-argument form is
+-- only STABLE), which is what allows IMMUTABLE here and lets the planner
+-- inline the call. No SET search_path clause on purpose: it would block
+-- that inlining, and unaccent lives in public.
+CREATE OR REPLACE FUNCTION cop_norm(t text) RETURNS text
+    LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE AS
+$$ SELECT lower(unaccent('unaccent', regexp_replace(t, '[’‘´`]', '''', 'g'))) $$;
+
+COMMENT ON FUNCTION cop_norm(text) IS
+    'Case/accent/apostrophe folding for literal search (Esatta modes).';
+
+-----------------------------------------------------------
+-- 6. Editions table
 -----------------------------------------------------------
 CREATE TABLE editions (
     id              SERIAL PRIMARY KEY,
@@ -48,9 +64,15 @@ CREATE TABLE editions (
     caption         TEXT NOT NULL,
     kicker          TEXT,
     image_filename  TEXT NOT NULL,
+    -- Whole record (caption + kicker), for "Tutto il testo" under Varianti
     search_vector   TSVECTOR GENERATED ALWAYS AS (
         setweight(to_tsvector('italian_unaccent', coalesce(caption, '')), 'A') ||
         setweight(to_tsvector('italian_unaccent', coalesce(kicker, '')), 'B')
+    ) STORED,
+    -- Caption alone, for "Solo titolo" under Varianti. search_vector cannot
+    -- answer that query: a kicker hit would still satisfy @@.
+    caption_vector  TSVECTOR GENERATED ALWAYS AS (
+        to_tsvector('italian_unaccent', coalesce(caption, ''))
     ) STORED,
     created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
@@ -58,11 +80,17 @@ CREATE TABLE editions (
 
 CREATE INDEX idx_editions_date ON editions (edition_date DESC);
 CREATE INDEX idx_editions_search ON editions USING GIN (search_vector);
+CREATE INDEX idx_editions_caption_search ON editions USING GIN (caption_vector);
 
 -----------------------------------------------------------
--- 6. Final Permissions Check
+-- 7. Final Permissions Check
 -----------------------------------------------------------
--- Ensure the app user owns the schema and all objects within it
+-- Ensure the app user owns the schema and all objects within it.
+-- ALTER SCHEMA alone is not enough: objects created by the superuser running
+-- this script stay owned by that superuser, which then blocks copertine_app
+-- from running migrations against them.
 ALTER SCHEMA public OWNER TO copertine_app;
+ALTER TABLE editions OWNER TO copertine_app;
+ALTER FUNCTION cop_norm(text) OWNER TO copertine_app;
 GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO copertine_app;
 GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO copertine_app;

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,10 @@
 # Base image for Node.js
 FROM node:20-alpine AS base
 
-# Install pnpm
+# Install pnpm. The version comes from the "packageManager" field in
+# package.json — without that pin corepack resolves to whatever pnpm is
+# newest at build time, which is how this image stopped building: pnpm 11
+# cannot be loaded by the corepack bundled in node:20-alpine.
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable

--- a/frontend/app/api/copertine/route.ts
+++ b/frontend/app/api/copertine/route.ts
@@ -2,91 +2,196 @@
 import { NextRequest } from 'next/server';
 import pool from '@/app/lib/db';
 
+const FTS_CONFIG = 'italian_unaccent';
+
+const DEFAULT_LIMIT = 30;
+const MAX_LIMIT = 100;
+
+type Mode = 'esatta' | 'varianti';
+type Scope = 'titolo' | 'tutto';
+type Sort = 'data' | 'titolo' | 'rilevanza';
+
+interface Criteria {
+  q: string;
+  mode: Mode;
+  /** Whole word vs. substring. Only meaningful under `esatta`: `varianti`
+   *  runs on a tsvector, which is tokenized and so always word-level. */
+  whole: boolean;
+  scope: Scope;
+  sort: Sort;
+  dir: 'ASC' | 'DESC';
+  offset: number;
+  limit: number;
+}
+
+/** parseInt('abc') is NaN, and Postgres rejects OFFSET 'NaN' with a 500. */
+function clampInt(raw: string | null, fallback: number, min: number, max: number): number {
+  const n = Number.parseInt(raw ?? '', 10);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(Math.max(n, min), max);
+}
+
+function parseCriteria(sp: URLSearchParams): Criteria {
+  const q = sp.get('q')?.trim() ?? '';
+  const mode: Mode = sp.get('mode') === 'varianti' ? 'varianti' : 'esatta';
+  const scope: Scope = sp.get('scope') === 'titolo' ? 'titolo' : 'tutto';
+  // Default to whole-word: it is the least surprising reading of "Esatta".
+  const whole = sp.get('whole') !== '0';
+
+  // Relevance only exists where there is a rank to sort on.
+  const rawSort = sp.get('sort');
+  const sort: Sort =
+    rawSort === 'titolo'
+      ? 'titolo'
+      : rawSort === 'rilevanza' && mode === 'varianti' && q
+        ? 'rilevanza'
+        : rawSort === 'data'
+          ? 'data'
+          : mode === 'varianti' && q
+            ? 'rilevanza'
+            : 'data';
+
+  return {
+    q,
+    mode,
+    whole,
+    scope,
+    sort,
+    dir: sp.get('dir') === 'asc' ? 'ASC' : 'DESC',
+    offset: clampInt(sp.get('offset'), 0, 0, Number.MAX_SAFE_INTEGER),
+    limit: clampInt(sp.get('limit'), DEFAULT_LIMIT, 1, MAX_LIMIT),
+  };
+}
+
+/**
+ * Escapes every character that is not a letter, digit or space. Blunt, but it
+ * cannot under-escape: in a Postgres ARE, a backslash before a
+ * non-alphanumeric character always means that literal character.
+ */
+function escapeRegex(s: string): string {
+  return s.replace(/[^\p{L}\p{N}\s]/gu, '\\$&');
+}
+
+/**
+ * `\y` asserts a word boundary, but only anchors correctly next to a word
+ * character — asserting one beside leading/trailing punctuation would never
+ * match (e.g. searching «guerra» with the quotes included).
+ */
+function wholeWordPattern(q: string): string {
+  const left = /^[\p{L}\p{N}_]/u.test(q) ? '\\y' : '';
+  const right = /[\p{L}\p{N}_]$/u.test(q) ? '\\y' : '';
+  return `${left}${escapeRegex(q)}${right}`;
+}
+
+/** Builds the WHERE clause plus its single bind parameter ($1). */
+function buildPredicate({ q, mode, whole, scope }: Criteria): { where: string; param: string } {
+  if (mode === 'varianti') {
+    const vector = scope === 'titolo' ? 'caption_vector' : 'search_vector';
+    return {
+      where: `${vector} @@ websearch_to_tsquery('${FTS_CONFIG}', $1)`,
+      param: q,
+    };
+  }
+
+  // Literal modes run through cop_norm() on both sides, which folds case,
+  // accents and the two apostrophe forms the corpus mixes.
+  const columns = scope === 'titolo' ? ['caption'] : ['caption', "coalesce(kicker, '')"];
+
+  if (whole) {
+    return {
+      where: columns.map((c) => `cop_norm(${c}) ~ cop_norm($1)`).join(' OR '),
+      param: wholeWordPattern(q),
+    };
+  }
+
+  // strpos() rather than ILIKE '%'||$1||'%': a literal % or _ in the needle
+  // would otherwise act as a wildcard and match everything.
+  return {
+    where: columns.map((c) => `strpos(cop_norm(${c}), cop_norm($1)) > 0`).join(' OR '),
+    param: q,
+  };
+}
+
+/**
+ * Extra select-list columns. `varianti` gets a rank to sort on and
+ * ts_headline markup; the literal modes are highlighted client-side, since
+ * cop_norm() shifts offsets and so cannot drive server-side markup.
+ */
+function buildProjection({ mode, scope }: Criteria): string {
+  if (mode !== 'varianti') return '';
+
+  const vector = scope === 'titolo' ? 'caption_vector' : 'search_vector';
+  const headline = (col: string) =>
+    `ts_headline('${FTS_CONFIG}', ${col}, websearch_to_tsquery('${FTS_CONFIG}', $1),
+       'HighlightAll=true, StartSel=<mark>, StopSel=</mark>') AS ${col}_hl`;
+
+  return [
+    `ts_rank(${vector}, websearch_to_tsquery('${FTS_CONFIG}', $1)) AS rank`,
+    headline('caption'),
+    // Out of scope under "Solo titolo" — highlighting it would mark text the
+    // query never searched.
+    ...(scope === 'tutto' ? [headline('kicker')] : []),
+  ].join(',\n                 ');
+}
+
+/**
+ * Whitelisted, never interpolated from raw input. `id` is appended as a
+ * tiebreaker so OFFSET paging stays deterministic when the sort key ties.
+ */
+function buildOrderBy({ sort, dir }: Criteria): string {
+  switch (sort) {
+    case 'rilevanza':
+      return `rank DESC, edition_date DESC, id DESC`;
+    case 'titolo':
+      return `cop_norm(caption) ${dir}, id DESC`;
+    default:
+      return `edition_date ${dir}, id DESC`;
+  }
+}
+
 export async function GET(request: NextRequest) {
-  const searchParams = request.nextUrl.searchParams;
-  const q = searchParams.get('q')?.trim() || '';
-  const mode = searchParams.get('mode') === 'varianti' ? 'varianti' : 'esatta';
-  const offset = parseInt(searchParams.get('offset') || '0');
-  const limit = parseInt(searchParams.get('limit') || '30');
+  const criteria = parseCriteria(request.nextUrl.searchParams);
+  const { q, offset, limit } = criteria;
 
   try {
-    if (q) {
-      if (mode === 'esatta') {
-        // Exact substring match — ILIKE, ordered by date
-        const searchQuery = `
-          SELECT edition_id, edition_date, caption, kicker, image_filename
-          FROM editions
-          WHERE caption ILIKE '%' || $1 || '%' OR kicker ILIKE '%' || $1 || '%'
-          ORDER BY edition_date DESC LIMIT $2 OFFSET $3
-        `;
-        const countQuery = `
-          SELECT count(*)::int AS total
-          FROM editions
-          WHERE caption ILIKE '%' || $1 || '%' OR kicker ILIKE '%' || $1 || '%'
-        `;
+    const { where, param } = q
+      ? buildPredicate(criteria)
+      : { where: '', param: '' };
 
-        const [{ rows }, { rows: countRows }] = await Promise.all([
-          pool.query(searchQuery, [q, limit, offset]),
-          pool.query(countQuery, [q]),
-        ]);
+    const whereClause = q ? `WHERE ${where}` : '';
+    const projection = q ? buildProjection(criteria) : '';
+    const orderBy = buildOrderBy(criteria);
 
-        const total: number = countRows[0].total;
+    // Bind params are positional, so the predicate's $1 must be omitted
+    // entirely when browsing.
+    const params = q ? [param, limit, offset] : [limit, offset];
+    const [limitPos, offsetPos] = q ? ['$2', '$3'] : ['$1', '$2'];
 
-        return Response.json({
-          data: rows.map(rowToEntry),
-          pagination: { total, offset, limit, hasMore: offset + limit < total },
-        });
-      } else {
-        // Full-text search mode — stemmed, ranked by relevance
-        const searchQuery = `
-          SELECT edition_id, edition_date, caption, kicker, image_filename,
-                 ts_rank(search_vector, websearch_to_tsquery('italian_unaccent', $1)) AS rank,
-                 ts_headline('italian_unaccent', caption, websearch_to_tsquery('italian_unaccent', $1),
-                   'HighlightAll=true, StartSel=<mark>, StopSel=</mark>') AS caption_hl,
-                 ts_headline('italian_unaccent', kicker, websearch_to_tsquery('italian_unaccent', $1),
-                   'HighlightAll=true, StartSel=<mark>, StopSel=</mark>') AS kicker_hl
-          FROM editions
-          WHERE search_vector @@ websearch_to_tsquery('italian_unaccent', $1)
-          ORDER BY rank DESC LIMIT $2 OFFSET $3
-        `;
-        const countQuery = `
-          SELECT count(*)::int AS total
-          FROM editions
-          WHERE search_vector @@ websearch_to_tsquery('italian_unaccent', $1)
-        `;
+    const dataQuery = `
+      SELECT edition_id, edition_date, caption, kicker, image_filename${projection ? `,
+             ${projection}` : ''}
+      FROM editions
+      ${whereClause}
+      ORDER BY ${orderBy}
+      LIMIT ${limitPos} OFFSET ${offsetPos}
+    `;
+    const countQuery = `
+      SELECT count(*)::int AS total
+      FROM editions
+      ${whereClause}
+    `;
 
-        const [{ rows }, { rows: countRows }] = await Promise.all([
-          pool.query(searchQuery, [q, limit, offset]),
-          pool.query(countQuery, [q]),
-        ]);
+    const [{ rows }, { rows: countRows }] = await Promise.all([
+      pool.query(dataQuery, params),
+      pool.query(countQuery, q ? [param] : []),
+    ]);
 
-        const total: number = countRows[0].total;
+    const total: number = countRows[0].total;
 
-        return Response.json({
-          data: rows.map(rowToEntry),
-          pagination: { total, offset, limit, hasMore: offset + limit < total },
-        });
-      }
-    } else {
-      // Browse mode — ordered by date desc
-      const browseQuery = `
-        SELECT edition_id, edition_date, caption, kicker, image_filename
-        FROM editions ORDER BY edition_date DESC LIMIT $1 OFFSET $2
-      `;
-      const countQuery = `SELECT count(*)::int AS total FROM editions`;
-
-      const [{ rows }, { rows: countRows }] = await Promise.all([
-        pool.query(browseQuery, [limit, offset]),
-        pool.query(countQuery),
-      ]);
-
-      const total: number = countRows[0].total;
-
-      return Response.json({
-        data: rows.map(rowToEntry),
-        pagination: { total, offset, limit, hasMore: offset + limit < total },
-      });
-    }
+    return Response.json({
+      data: rows.map(rowToEntry),
+      pagination: { total, offset, limit, hasMore: offset + limit < total },
+    });
   } catch (error) {
     console.error('Database query failed:', error);
     return Response.json({ error: 'Failed to fetch data' }, { status: 500 });

--- a/frontend/app/components/copertina/CopertinaCard.tsx
+++ b/frontend/app/components/copertina/CopertinaCard.tsx
@@ -1,11 +1,16 @@
 // app/components/copertina/CopertinaCard.tsx
 import { useState, useEffect } from "react";
 import { CopertineEntry } from "@app/types/copertine";
+import type { SearchScope } from "@app/types/search";
+import { matchRanges } from "@app/lib/highlight";
 import Image from "next/image";
 
 interface CopertinaCardProps {
   copertina: CopertineEntry;
   searchTerm?: string;
+  /** Mirrors the Granularita switch, so highlights match what was searched. */
+  matchWholeWord?: boolean;
+  scope?: SearchScope;
 }
 
 const months = [
@@ -16,6 +21,9 @@ const months = [
 const days = [
   'Domenica', 'Lunedì', 'Martedì', 'Mercoledì', 'Giovedì', 'Venerdì', 'Sabato'
 ];
+
+const MARK_CLASS =
+  "bg-red-100 text-red-900 dark:bg-red-900/30 dark:text-red-200 px-1 rounded-sm font-medium";
 
 function formatItalianDate(isoDate: string): string {
   const date = new Date(isoDate);
@@ -33,33 +41,47 @@ const parseHighlights = (html: string): React.ReactNode => {
   const parts = html.split(/(<mark>[\s\S]*?<\/mark>)/g);
   return parts.map((part, i) => {
     if (part.startsWith('<mark>')) {
-      return <span key={i} className="bg-red-100 text-red-900 dark:bg-red-900/30 dark:text-red-200 px-1 rounded-sm font-medium">{part.slice(6, -7)}</span>;
+      return <span key={i} className={MARK_CLASS}>{part.slice(6, -7)}</span>;
     }
     return part;
   });
 };
 
-// Fallback: highlight exact search term when ts_headline data is unavailable
-const highlightText = (text: string, searchTerm: string) => {
-  if (!searchTerm?.trim()) return text;
+/** Client-side highlighting for the literal (Esatta) modes. */
+function highlightText(text: string, searchTerm: string, wholeWord: boolean): React.ReactNode {
+  if (!searchTerm?.trim() || !text) return text;
 
-  const escapedSearchTerm = searchTerm.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const parts = text.split(new RegExp(`(${escapedSearchTerm})`, 'gi'));
+  const ranges = matchRanges(text, searchTerm, wholeWord);
+  if (ranges.length === 0) return text;
 
-  return parts.map((part, i) => {
-    if (part.toLowerCase() === searchTerm.toLowerCase()) {
-      return <span key={i} className="bg-red-100 text-red-900 dark:bg-red-900/30 dark:text-red-200 px-1 rounded-sm font-medium">{part}</span>;
-    }
-    return part;
+  const nodes: React.ReactNode[] = [];
+  let cursor = 0;
+
+  ranges.forEach(([start, end], i) => {
+    if (start > cursor) nodes.push(text.slice(cursor, start));
+    nodes.push(<span key={i} className={MARK_CLASS}>{text.slice(start, end)}</span>);
+    cursor = end;
   });
-};
+  if (cursor < text.length) nodes.push(text.slice(cursor));
 
-export default function CopertinaCard({ copertina, searchTerm }: CopertinaCardProps) {
+  return nodes;
+}
+
+export default function CopertinaCard({
+  copertina,
+  searchTerm,
+  matchWholeWord = true,
+  scope = 'tutto',
+}: CopertinaCardProps) {
   const [isPopupVisible, setIsPopupVisible] = useState(false);
 
   // Direct image path — no cache layer needed
   const imagePath = `/images/${copertina.filename}`;
   const formattedDate = formatItalianDate(copertina.isoDate);
+
+  // Under "Solo titolo" the kicker was never searched, so marking it would
+  // claim a match the query never made.
+  const kickerTerm = scope === 'titolo' ? '' : (searchTerm || '');
 
   const togglePopup = () => setIsPopupVisible(!isPopupVisible);
   const closePopup = () => setIsPopupVisible(false);
@@ -86,7 +108,7 @@ export default function CopertinaCard({ copertina, searchTerm }: CopertinaCardPr
           <div className="font-semibold text-gray-900 dark:text-gray-100">
             {copertina.caption_hl
               ? parseHighlights(copertina.caption_hl)
-              : highlightText(copertina.extracted_caption, searchTerm || '')}
+              : highlightText(copertina.extracted_caption, searchTerm || '', matchWholeWord)}
           </div>
           <span className="text-gray-600 dark:text-gray-300">-</span>
           <div className="text-gray-600 dark:text-gray-300">
@@ -116,7 +138,7 @@ export default function CopertinaCard({ copertina, searchTerm }: CopertinaCardPr
             <p className="text-justify">
               {copertina.kicker_hl
                 ? parseHighlights(copertina.kicker_hl)
-                : highlightText(copertina.kickerStr, searchTerm || '')}
+                : highlightText(copertina.kickerStr, kickerTerm, matchWholeWord)}
             </p>
           </div>
         </div>

--- a/frontend/app/components/searchsection/SearchSection.tsx
+++ b/frontend/app/components/searchsection/SearchSection.tsx
@@ -3,27 +3,101 @@
 
 import React, { useState } from 'react';
 import { Search, ListRestart } from 'lucide-react';
-
-export type SearchMode = 'esatta' | 'varianti';
+import {
+  DEFAULT_OPTIONS,
+  type SearchMode,
+  type SearchOptions,
+  type SearchScope,
+} from '@app/types/search';
 
 interface SearchSectionProps {
-  onSearch: (query: string, mode: SearchMode) => void;
+  onSearch: (query: string, options: SearchOptions) => void;
   onReset: () => void;
   isSearchResult: boolean;
 }
 
+interface ToggleGroupProps<T extends string> {
+  label: string;
+  value: T;
+  options: ReadonlyArray<{ value: T; label: string; hint: string }>;
+  onChange: (value: T) => void;
+  disabled?: boolean;
+  disabledHint?: string;
+}
+
+function ToggleGroup<T extends string>({
+  label,
+  value,
+  options,
+  onChange,
+  disabled = false,
+  disabledHint,
+}: ToggleGroupProps<T>) {
+  return (
+    <div className={`flex flex-col gap-1 ${disabled ? 'opacity-50' : ''}`} title={disabled ? disabledHint : undefined}>
+      <span className="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+        {label}
+      </span>
+      <div className="flex rounded-lg p-1 bg-gray-100 dark:bg-gray-800 h-11 items-center" role="group" aria-label={label}>
+        {options.map((option) => (
+          <button
+            key={option.value}
+            type="button"
+            disabled={disabled}
+            aria-pressed={value === option.value}
+            title={disabled ? disabledHint : option.hint}
+            onClick={() => onChange(option.value)}
+            className={`px-3 py-2 h-full rounded-md text-sm font-medium transition-all duration-200 whitespace-nowrap ${
+              value === option.value
+                ? 'bg-white dark:bg-gray-700 text-red-600 dark:text-red-400 shadow-sm'
+                : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
+            } ${disabled ? 'cursor-not-allowed' : ''}`}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const SCOPE_OPTIONS = [
+  { value: 'titolo', label: 'Solo titolo', hint: 'Cerca solo nel titolo della copertina' },
+  { value: 'tutto', label: 'Tutto il testo', hint: 'Cerca nel titolo e nel sommario' },
+] as const satisfies ReadonlyArray<{ value: SearchScope; label: string; hint: string }>;
+
+const MODE_OPTIONS = [
+  { value: 'esatta', label: 'Esatta', hint: 'Trova il testo cosi come e stato scritto (ignora maiuscole e accenti)' },
+  { value: 'varianti', label: 'Varianti', hint: 'Trova anche le varianti della parola: "guerra" trova "guerre"' },
+] as const satisfies ReadonlyArray<{ value: SearchMode; label: string; hint: string }>;
+
+const GRANULARITY_OPTIONS = [
+  { value: 'parola', label: 'Parola intera', hint: '"ago" non trova "fragole"' },
+  { value: 'stringa', label: 'Stringa', hint: '"ago" trova anche "fragole"' },
+] as const;
+
+const GRANULARITY_LOCKED =
+  'La ricerca per varianti lavora sempre su parole intere';
+
 export default function SearchSection({ onSearch, onReset, isSearchResult }: SearchSectionProps) {
   const [searchTerm, setSearchTerm] = useState('');
   const [isSearching, setIsSearching] = useState(false);
-  const [searchMode, setSearchMode] = useState<SearchMode>('esatta');
+  const [options, setOptions] = useState<SearchOptions>(DEFAULT_OPTIONS);
+
+  // Varianti is inherently word-level, so the granularity switch is locked
+  // there. The user's own choice is kept in state for when they switch back.
+  const granularityLocked = options.mode === 'varianti';
+  const effectiveWhole = granularityLocked ? true : options.whole;
+
+  const canSearch = searchTerm.trim().length >= 2;
 
   const handleSearch = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!searchTerm.trim() || searchTerm.trim().length < 2) return;
+    if (!canSearch) return;
 
     setIsSearching(true);
     try {
-      await onSearch(searchTerm.trim(), searchMode);
+      await onSearch(searchTerm.trim(), { ...options, whole: effectiveWhole });
     } finally {
       setIsSearching(false);
     }
@@ -34,16 +108,16 @@ export default function SearchSection({ onSearch, onReset, isSearchResult }: Sea
     onReset();
   };
 
-  const searchButtonClasses = `h-12 flex-1 sm:w-auto px-6 rounded-lg transition-all duration-200 font-medium flex items-center justify-center shadow-sm hover:shadow-md active:scale-[0.98] ${
-    searchTerm.trim().length >= 2
-      ? "bg-red-600 hover:bg-red-700 text-white"
-      : "bg-gray-100 dark:bg-gray-800 text-gray-400 dark:text-gray-500 cursor-not-allowed shadow-none hover:shadow-none active:scale-100"
+  const searchButtonClasses = `h-11 flex-1 sm:w-auto px-6 rounded-lg transition-all duration-200 font-medium flex items-center justify-center shadow-sm hover:shadow-md active:scale-[0.98] ${
+    canSearch
+      ? 'bg-red-600 hover:bg-red-700 text-white'
+      : 'bg-gray-100 dark:bg-gray-800 text-gray-400 dark:text-gray-500 cursor-not-allowed shadow-none hover:shadow-none active:scale-100'
   }`;
 
-  const resetButtonClasses = `h-12 sm:w-auto px-4 rounded-lg transition-all duration-200 font-medium flex items-center justify-center gap-2 ${
+  const resetButtonClasses = `h-11 sm:w-auto px-4 rounded-lg transition-all duration-200 font-medium flex items-center justify-center gap-2 ${
     isSearchResult
-      ? "text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/20 hover:bg-blue-100 dark:hover:bg-blue-900/40 cursor-pointer"
-      : "text-gray-400 dark:text-gray-500 bg-transparent cursor-not-allowed"
+      ? 'text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/20 hover:bg-blue-100 dark:hover:bg-blue-900/40 cursor-pointer'
+      : 'text-gray-400 dark:text-gray-500 bg-transparent cursor-not-allowed'
   }`;
 
   return (
@@ -51,63 +125,65 @@ export default function SearchSection({ onSearch, onReset, isSearchResult }: Sea
       <div className="bg-red-600 h-1 w-full" />
       <div className="w-full bg-white dark:bg-black border-b border-gray-200 dark:border-gray-800">
         <div className="max-w-4xl mx-auto px-4 py-6">
-          <form onSubmit={handleSearch} className="space-y-6">
-            <div className="flex flex-col gap-4">
-              <div className="flex flex-col sm:flex-row gap-4 items-center">
-                <div className="flex-1 flex items-center gap-4">
-                  <label htmlFor="search" className="text-lg font-medium text-gray-700 dark:text-gray-300 whitespace-nowrap">
-                    Cerca
-                  </label>
-                  <div className="relative flex-1">
-                    <input
-                      type="text"
-                      id="search"
-                      value={searchTerm}
-                      onChange={(e) => setSearchTerm(e.target.value)}
-                      className="w-full px-4 py-2 h-10 rounded-lg border border-gray-200 dark:border-gray-800 bg-gray-200 dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent outline-none"
-                      placeholder="Inserisci il testo da cercare..."
-                    />
-                    <Search className="absolute right-3 top-1/2 -translate-y-1/2 h-5 w-5 text-gray-500" />
-                  </div>
-                </div>
-                <div className="sm:self-auto flex gap-2 items-center">
-                  {/* Mode toggle */}
-                  <div className="flex rounded-lg p-1 bg-gray-100 dark:bg-gray-800 h-12 items-center">
-                    {(['esatta', 'varianti'] as SearchMode[]).map((mode) => (
-                      <button
-                        key={mode}
-                        type="button"
-                        onClick={() => setSearchMode(mode)}
-                        className={`px-4 py-2 h-full rounded-md text-sm font-medium transition-all duration-200 ${
-                          searchMode === mode
-                            ? 'bg-white dark:bg-gray-700 text-red-600 dark:text-red-400 shadow-sm'
-                            : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
-                        }`}
-                      >
-                        {mode.charAt(0).toUpperCase() + mode.slice(1)}
-                      </button>
-                    ))}
-                  </div>
+          <form onSubmit={handleSearch} className="flex flex-col gap-4">
+            {/* Query row */}
+            <div className="flex flex-col sm:flex-row gap-4 items-center">
+              <label htmlFor="search" className="text-lg font-medium text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                Cerca
+              </label>
+              <div className="relative flex-1 w-full">
+                <input
+                  type="text"
+                  id="search"
+                  value={searchTerm}
+                  onChange={(e) => setSearchTerm(e.target.value)}
+                  className="w-full px-4 py-2 h-10 rounded-lg border border-gray-200 dark:border-gray-800 bg-gray-200 dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent outline-none"
+                  placeholder="Inserisci il testo da cercare..."
+                />
+                <Search className="absolute right-3 top-1/2 -translate-y-1/2 h-5 w-5 text-gray-500" />
+              </div>
+            </div>
 
-                  <button
-                    type="submit"
-                    disabled={isSearching || searchTerm.trim().length < 2}
-                    className={searchButtonClasses}
-                  >
-                    {isSearching ? 'Ricerca...' : 'Cerca'}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handleReset}
-                    disabled={!isSearchResult}
-                    className={resetButtonClasses}
-                    title="Torna alla lista completa"
-                  >
-                    <ListRestart className="w-4 h-4" />
-                    <span className="hidden sm:inline">Lista completa</span>
-                    <span className="sm:hidden">Reset</span>
-                  </button>
-                </div>
+            {/* Switches + actions */}
+            <div className="flex flex-col lg:flex-row gap-4 lg:items-end lg:justify-between">
+              <div className="flex flex-wrap gap-3">
+                <ToggleGroup
+                  label="Ambito"
+                  value={options.scope}
+                  options={SCOPE_OPTIONS}
+                  onChange={(scope) => setOptions((o) => ({ ...o, scope }))}
+                />
+                <ToggleGroup
+                  label="Corrispondenza"
+                  value={options.mode}
+                  options={MODE_OPTIONS}
+                  onChange={(mode) => setOptions((o) => ({ ...o, mode }))}
+                />
+                <ToggleGroup
+                  label="Granularita"
+                  value={effectiveWhole ? 'parola' : 'stringa'}
+                  options={GRANULARITY_OPTIONS}
+                  onChange={(v) => setOptions((o) => ({ ...o, whole: v === 'parola' }))}
+                  disabled={granularityLocked}
+                  disabledHint={GRANULARITY_LOCKED}
+                />
+              </div>
+
+              <div className="flex gap-2 items-center">
+                <button type="submit" disabled={isSearching || !canSearch} className={searchButtonClasses}>
+                  {isSearching ? 'Ricerca...' : 'Cerca'}
+                </button>
+                <button
+                  type="button"
+                  onClick={handleReset}
+                  disabled={!isSearchResult}
+                  className={resetButtonClasses}
+                  title="Torna alla lista completa"
+                >
+                  <ListRestart className="w-4 h-4" />
+                  <span className="hidden sm:inline">Lista completa</span>
+                  <span className="sm:hidden">Reset</span>
+                </button>
               </div>
             </div>
           </form>

--- a/frontend/app/copertine/page.tsx
+++ b/frontend/app/copertine/page.tsx
@@ -4,39 +4,47 @@ import React from "react";
 import { ChevronUp, ChevronDown } from "lucide-react";
 import CopertinaCard from "../components/copertina/CopertinaCard";
 import PaginationControls from "../components/PaginationControls";
-import SearchSection, { type SearchMode } from "../components/searchsection/SearchSection";
-import type {
-  CopertineEntry,
-  CopertineResponse,
-  PaginationInfo,
-} from "../types/copertine";
+import SearchSection from "../components/searchsection/SearchSection";
+import type { CopertineEntry, CopertineResponse, PaginationInfo } from "../types/copertine";
+import {
+  DEFAULT_CRITERIA,
+  criteriaToQueryString,
+  supportsRelevance,
+  type SearchCriteria,
+  type SearchOptions,
+  type SortField,
+} from "../types/search";
 import { PAGINATION } from "@/app/lib/config/constants";
 
-type SortField = "date" | "extracted_caption" | "relevance";
-type SortDirection = "asc" | "desc";
+const EMPTY_PAGINATION: PaginationInfo = {
+  total: 0,
+  offset: 0,
+  limit: PAGINATION.ITEMS_PER_PAGE,
+  hasMore: false,
+};
 
 export default function Home() {
-  // State declarations
   const [copertine, setCopertine] = React.useState<CopertineEntry[]>([]);
-  const [originalOrder, setOriginalOrder] = React.useState<CopertineEntry[]>([]);
-  const [isSearchResult, setIsSearchResult] = React.useState(false);
-  const [currentSearchTerm, setCurrentSearchTerm] = React.useState<string>('');
+  const [criteria, setCriteria] = React.useState<SearchCriteria>(DEFAULT_CRITERIA);
   const [pagination, setPagination] = React.useState<PaginationInfo>({
-    total: 0,
-    offset: 0,
-    limit: PAGINATION.ITEMS_PER_PAGE,
+    ...EMPTY_PAGINATION,
     hasMore: true,
   });
-  const [sortField, setSortField] = React.useState<SortField>("date");
-  const [sortDirection, setSortDirection] = React.useState<SortDirection>("desc");
   const [isLoading, setIsLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
 
-  // Fetch a browse page (no search query)
-  const fetchPage = React.useCallback(async (offset: number) => {
+  /**
+   * The single fetch path. Every navigation — search, sort, paging — goes
+   * through here with a complete criteria object, so paging can no longer
+   * drop the active query the way the old separate browse/search calls did.
+   */
+  const fetchResults = React.useCallback(async (next: SearchCriteria) => {
     try {
       setIsLoading(true);
-      const url = `/api/copertine?offset=${offset}&limit=${pagination.limit}`;
+      setError(null);
+      setCriteria(next);
+
+      const url = `/api/copertine?${criteriaToQueryString(next, PAGINATION.ITEMS_PER_PAGE)}`;
       const response = await fetch(url);
 
       if (!response.ok) {
@@ -46,129 +54,105 @@ export default function Home() {
 
       const data: CopertineResponse = await response.json();
       if (!data.data || !Array.isArray(data.data)) {
-        throw new Error('Invalid data format received');
+        throw new Error("Invalid data format received");
       }
 
       setCopertine(data.data);
-      setOriginalOrder(data.data);
       setPagination(data.pagination);
-      setIsSearchResult(false);
-      setCurrentSearchTerm('');
-      setSortField('date');
-      setError(null);
+
+      if (data.data.length === 0 && next.q) {
+        setError(`Nessun risultato trovato per "${next.q}"`);
+      }
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load data');
+      setError(err instanceof Error ? err.message : "Failed to load data");
       setCopertine([]);
-      setOriginalOrder([]);
-      setPagination({ total: 0, offset: 0, limit: PAGINATION.ITEMS_PER_PAGE, hasMore: false });
+      setPagination(EMPTY_PAGINATION);
     } finally {
       setIsLoading(false);
     }
-  }, [pagination.limit]);
+  }, []);
 
-  // Handle search via the unified API route
-  const handleSearch = React.useCallback(async (query: string, mode: SearchMode) => {
-    try {
-      setIsLoading(true);
-      setError(null);
-      const url = `/api/copertine?q=${encodeURIComponent(query)}&mode=${mode}&limit=${pagination.limit}&offset=0`;
-      const response = await fetch(url);
+  const handleSearch = React.useCallback(
+    (query: string, options: SearchOptions) => {
+      const next: SearchCriteria = {
+        ...options,
+        q: query,
+        // Relevance is the useful default where a rank exists.
+        sort: options.mode === "varianti" ? "rilevanza" : "data",
+        dir: "desc",
+        offset: 0,
+      };
+      return fetchResults(next);
+    },
+    [fetchResults],
+  );
 
-      if (!response.ok) {
-        const errorText = await response.text();
-        throw new Error(`Search failed: ${response.status} ${errorText}`);
-      }
+  const handleReset = React.useCallback(() => fetchResults(DEFAULT_CRITERIA), [fetchResults]);
 
-      const data: CopertineResponse = await response.json();
-      if (!data.data || !Array.isArray(data.data)) {
-        throw new Error('Invalid data format received');
-      }
+  // Ordering happens in SQL over the whole result set, not just the loaded
+  // page, so changing it refetches from offset 0.
+  const handleSort = React.useCallback(
+    (field: SortField) => {
+      const dir =
+        field === "rilevanza"
+          ? "desc"
+          : criteria.sort === field && criteria.dir === "desc"
+            ? "asc"
+            : "desc";
+      fetchResults({ ...criteria, sort: field, dir, offset: 0 });
+    },
+    [criteria, fetchResults],
+  );
 
-      setCopertine(data.data);
-      setOriginalOrder(data.data);
-      setPagination(data.pagination);
-      setIsSearchResult(true);
-      setCurrentSearchTerm(query);
-      setSortField(mode === 'varianti' ? 'relevance' : 'date');
-
-      if (data.data.length === 0) {
-        setError(`Nessun risultato trovato per "${query}"`);
-      }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Search failed');
-      setCopertine([]);
-      setOriginalOrder([]);
-      setPagination({ total: 0, offset: 0, limit: PAGINATION.ITEMS_PER_PAGE, hasMore: false });
-    } finally {
-      setIsLoading(false);
-    }
-  }, [pagination.limit]);
-
-  // Reset to full browse list
-  const handleReset = React.useCallback(() => {
-    fetchPage(0);
-  }, [fetchPage]);
+  const handlePageChange = React.useCallback(
+    (newPage: number) => {
+      fetchResults({ ...criteria, offset: (newPage - 1) * PAGINATION.ITEMS_PER_PAGE });
+    },
+    [criteria, fetchResults],
+  );
 
   // Initial load
   React.useEffect(() => {
-    fetchPage(0);
-  }, [fetchPage]);
+    fetchResults(DEFAULT_CRITERIA);
+  }, [fetchResults]);
 
-  // Sort handling
-  const handleSort = (field: SortField) => {
-    if (field === "relevance") {
-      if (!isSearchResult) return;
-      setSortField("relevance");
-      setSortDirection("desc");
-      return;
-    }
+  const isSearchResult = criteria.q !== "";
+  const showRelevance = supportsRelevance(criteria);
 
-    if (field === sortField) {
-      setSortDirection((current) => (current === "asc" ? "desc" : "asc"));
-    } else {
-      setSortField(field);
-      setSortDirection("desc");
-    }
-  };
+  const sortButtonClasses = (field: SortField) =>
+    `flex items-center gap-2 px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-blue-100 dark:hover:bg-gray-700 rounded-md transition-colors ${
+      criteria.sort === field ? "bg-blue-100 dark:bg-gray-700" : ""
+    }`;
 
-  // Sort copertine based on current field and direction
-  const sortedCopertine = React.useMemo(() => {
-    if (sortField === "relevance" && isSearchResult) {
-      return originalOrder;
-    }
-
-    return [...copertine].sort((a, b) => {
-      const modifier = sortDirection === "asc" ? 1 : -1;
-
-      switch (sortField) {
-        case "date": {
-          const timeA = new Date(a.isoDate).getTime();
-          const timeB = new Date(b.isoDate).getTime();
-          return (timeA - timeB) * modifier;
-        }
-        case "extracted_caption":
-          return a.extracted_caption.localeCompare(b.extracted_caption) * modifier;
-        default:
-          return 0;
-      }
-    });
-  }, [copertine, sortField, sortDirection, originalOrder, isSearchResult]);
+  const chevrons = (field: SortField) => (
+    <div className="flex flex-col">
+      <ChevronUp
+        className={`h-3 w-3 -mb-1 ${
+          criteria.sort === field && criteria.dir === "asc"
+            ? "text-blue-600 dark:text-blue-400"
+            : "text-gray-400"
+        }`}
+      />
+      <ChevronDown
+        className={`h-3 w-3 ${
+          criteria.sort === field && criteria.dir === "desc"
+            ? "text-blue-600 dark:text-blue-400"
+            : "text-gray-400"
+        }`}
+      />
+    </div>
+  );
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
-      {/* Search bar — owned by page, passes callbacks */}
-      <SearchSection
-        onSearch={handleSearch}
-        onReset={handleReset}
-        isSearchResult={isSearchResult}
-      />
+      <SearchSection onSearch={handleSearch} onReset={handleReset} isSearchResult={isSearchResult} />
 
       <section className="max-w-4xl mx-auto px-4 py-6">
         {error && !isLoading ? (
           <div className="flex flex-col items-center justify-center min-h-[400px]">
             <div className="max-w-lg text-center space-y-4">
               <div className="text-xl font-semibold text-gray-900 dark:text-gray-100">
-                {isSearchResult ? 'Nessun risultato' : 'Impossibile caricare i dati'}
+                {isSearchResult ? "Nessun risultato" : "Impossibile caricare i dati"}
               </div>
               <div className="text-gray-600 dark:text-gray-400">{error}</div>
             </div>
@@ -179,86 +163,32 @@ export default function Home() {
               <div className="absolute top-0 left-0 w-full h-full border-4 border-gray-200 dark:border-gray-700 rounded-full"></div>
               <div className="absolute top-0 left-0 w-full h-full border-4 border-blue-500 dark:border-blue-400 rounded-full animate-spin border-t-transparent"></div>
             </div>
-            <div className="text-lg text-gray-600 dark:text-gray-400">
-              Caricamento copertine...
-            </div>
+            <div className="text-lg text-gray-600 dark:text-gray-400">Caricamento copertine...</div>
           </div>
         ) : (
           <div>
-            {/* Combined Sort and Pagination Controls */}
             <div className="mb-6 bg-white dark:bg-gray-800 rounded-lg shadow-sm p-4">
               <PaginationControls
                 currentPage={Math.floor(pagination.offset / pagination.limit) + 1}
                 totalPages={Math.ceil(pagination.total / pagination.limit)}
                 totalItems={pagination.total}
-                onPageChange={(newPage) => {
-                  const newOffset = (newPage - 1) * pagination.limit;
-                  fetchPage(newOffset);
-                }}
+                onPageChange={handlePageChange}
                 isLoading={isLoading}
               />
 
-              {/* Sort Controls */}
               <div className="flex gap-4 mt-4 pt-4 border-t border-gray-200 dark:border-gray-700">
-                <button
-                  onClick={() => handleSort("date")}
-                  className={`flex items-center gap-2 px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-blue-100 dark:hover:bg-gray-700 rounded-md transition-colors ${
-                    sortField === "date" ? "bg-blue-100 dark:bg-gray-700" : ""
-                  }`}
-                >
+                <button onClick={() => handleSort("data")} className={sortButtonClasses("data")}>
                   Data
-                  <div className="flex flex-col">
-                    <ChevronUp
-                      className={`h-3 w-3 -mb-1 ${
-                        sortField === "date" && sortDirection === "asc"
-                          ? "text-blue-600 dark:text-blue-400"
-                          : "text-gray-400"
-                      }`}
-                    />
-                    <ChevronDown
-                      className={`h-3 w-3 ${
-                        sortField === "date" && sortDirection === "desc"
-                          ? "text-blue-600 dark:text-blue-400"
-                          : "text-gray-400"
-                      }`}
-                    />
-                  </div>
+                  {chevrons("data")}
                 </button>
-                <button
-                  onClick={() => handleSort("extracted_caption")}
-                  className={`flex items-center gap-2 px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-blue-100 dark:hover:bg-gray-700 rounded-md transition-colors ${
-                    sortField === "extracted_caption"
-                      ? "bg-blue-100 dark:bg-gray-700"
-                      : ""
-                  }`}
-                >
+                <button onClick={() => handleSort("titolo")} className={sortButtonClasses("titolo")}>
                   Titolo
-                  <div className="flex flex-col">
-                    <ChevronUp
-                      className={`h-3 w-3 -mb-1 ${
-                        sortField === "extracted_caption" && sortDirection === "asc"
-                          ? "text-blue-600 dark:text-blue-400"
-                          : "text-gray-400"
-                      }`}
-                    />
-                    <ChevronDown
-                      className={`h-3 w-3 ${
-                        sortField === "extracted_caption" && sortDirection === "desc"
-                          ? "text-blue-600 dark:text-blue-400"
-                          : "text-gray-400"
-                      }`}
-                    />
-                  </div>
+                  {chevrons("titolo")}
                 </button>
-                {isSearchResult && (
+                {showRelevance && (
                   <button
-                    onClick={() => {
-                      setSortField("relevance");
-                      setSortDirection("desc");
-                    }}
-                    className={`px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-blue-100 dark:hover:bg-gray-700 rounded-md transition-colors ${
-                      sortField === "relevance" ? "bg-blue-100 dark:bg-gray-700" : ""
-                    }`}
+                    onClick={() => handleSort("rilevanza")}
+                    className={sortButtonClasses("rilevanza")}
                   >
                     Rilevanza
                   </button>
@@ -266,13 +196,14 @@ export default function Home() {
               </div>
             </div>
 
-            {/* Copertine Cards */}
             <div className="space-y-6">
-              {sortedCopertine.map((copertina) => (
+              {copertine.map((copertina) => (
                 <CopertinaCard
                   key={copertina.filename}
                   copertina={copertina}
-                  searchTerm={currentSearchTerm}
+                  searchTerm={criteria.q}
+                  matchWholeWord={criteria.whole}
+                  scope={criteria.scope}
                 />
               ))}
             </div>

--- a/frontend/app/lib/highlight.ts
+++ b/frontend/app/lib/highlight.ts
@@ -1,0 +1,67 @@
+// app/lib/highlight.ts — client-side highlighting for the literal (Esatta)
+// search modes. The Varianti mode is highlighted server-side by ts_headline.
+
+/**
+ * Folds case, accents and apostrophes the same way the SQL cop_norm() does,
+ * while recording where each folded character came from.
+ *
+ * Folding changes string length — é decomposes to two code points before the
+ * combining mark is dropped — so highlighting positions in the *original*
+ * text requires this index map. map[i] is the index, in original code units,
+ * of the character that produced folded character i.
+ */
+export function foldWithMap(input: string): { text: string; map: number[] } {
+  let text = '';
+  const map: number[] = [];
+  let origIndex = 0;
+
+  for (const ch of input) {
+    const folded = ch
+      .normalize('NFD')
+      .replace(/\p{M}/gu, '')
+      .replace(/[’‘´`]/g, "'")
+      .toLowerCase();
+
+    // One entry per code *unit*, not per code point: regex match indices are
+    // code-unit based, so a surrogate pair must contribute two entries or the
+    // map desyncs from `text` for everything after it.
+    text += folded;
+    for (let k = 0; k < folded.length; k++) map.push(origIndex);
+
+    origIndex += ch.length;
+  }
+
+  return { text, map };
+}
+
+/**
+ * Ranges of `text`, as [start, end) original-string indices, matching `term`
+ * under the given granularity.
+ */
+export function matchRanges(
+  text: string,
+  term: string,
+  wholeWord: boolean,
+): Array<[number, number]> {
+  const haystack = foldWithMap(text);
+  const needle = foldWithMap(term).text;
+  if (!needle) return [];
+
+  const escaped = needle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  // Lookarounds rather than \b: JavaScript's \b is ASCII-only and would
+  // mis-anchor on accented letters. Omitted where the needle starts or ends
+  // with punctuation, which could never sit against a word boundary.
+  const left = wholeWord && /^[\p{L}\p{N}_]/u.test(needle) ? '(?<![\\p{L}\\p{N}_])' : '';
+  const right = wholeWord && /[\p{L}\p{N}_]$/u.test(needle) ? '(?![\\p{L}\\p{N}_])' : '';
+
+  const ranges: Array<[number, number]> = [];
+  for (const match of haystack.text.matchAll(new RegExp(left + escaped + right, 'gu'))) {
+    const start = match.index;
+    const end = start + match[0].length;
+    ranges.push([
+      haystack.map[start],
+      end < haystack.map.length ? haystack.map[end] : text.length,
+    ]);
+  }
+  return ranges;
+}

--- a/frontend/app/types/search.ts
+++ b/frontend/app/types/search.ts
@@ -1,23 +1,68 @@
-// app/types/search.ts — simplified for PostgreSQL FTS
+// app/types/search.ts — the three search switches, shared by the form,
+// the results page and the card renderer.
 
-export interface SearchRequest {
-  query: string;
+/** Corrispondenza: literal match vs. Italian stemmer. */
+export type SearchMode = 'esatta' | 'varianti';
+
+/** Ambito: title only, or title + kicker. */
+export type SearchScope = 'titolo' | 'tutto';
+
+export type SortField = 'data' | 'titolo' | 'rilevanza';
+export type SortDirection = 'asc' | 'desc';
+
+/** What the search form submits. */
+export interface SearchOptions {
+  mode: SearchMode;
+  /**
+   * Granularita: whole word vs. substring. Only meaningful under `esatta` —
+   * `varianti` matches against a tsvector, which is tokenized and therefore
+   * always word-level.
+   */
+  whole: boolean;
+  scope: SearchScope;
 }
 
-export interface SearchResponse {
-  data: SearchEntry[];
-  pagination: {
-    total: number;
-    offset: number;
-    limit: number;
-    hasMore: boolean;
-  };
+/** A full request: what to search for, how to order it, and which page. */
+export interface SearchCriteria extends SearchOptions {
+  q: string;
+  sort: SortField;
+  dir: SortDirection;
+  offset: number;
 }
 
-export interface SearchEntry {
-  extracted_caption: string;
-  kickerStr: string;
-  date: string;
-  filename: string;
-  isoDate: string;
+export const DEFAULT_OPTIONS: SearchOptions = {
+  mode: 'esatta',
+  whole: true,
+  scope: 'tutto',
+};
+
+export const DEFAULT_CRITERIA: SearchCriteria = {
+  ...DEFAULT_OPTIONS,
+  q: '',
+  sort: 'data',
+  dir: 'desc',
+  offset: 0,
+};
+
+/** Relevance only exists where the backend produces a rank to sort on. */
+export function supportsRelevance(criteria: Pick<SearchCriteria, 'q' | 'mode'>): boolean {
+  return criteria.q !== '' && criteria.mode === 'varianti';
+}
+
+export function criteriaToQueryString(criteria: SearchCriteria, limit: number): string {
+  const params = new URLSearchParams({
+    limit: String(limit),
+    offset: String(criteria.offset),
+    sort: criteria.sort,
+    dir: criteria.dir,
+  });
+
+  if (criteria.q) {
+    params.set('q', criteria.q);
+    params.set('mode', criteria.mode);
+    params.set('scope', criteria.scope);
+    params.set('whole', criteria.whole ? '1' : '0');
+  }
+
+  return params.toString();
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "fecopertine",
   "version": "0.2.0",
   "private": true,
+  "packageManager": "pnpm@10.34.5",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## Why

`Esatta` and `Varianti` did the opposite of what they claimed. `Esatta` ran an unanchored `ILIKE '%q%'` — the *loosest* possible match, so searching `ago` returned 95 rows including *Il costo delle fragole* (`fr-ago-le`). `Varianti` ran a stemmed `tsquery` — the *strictest* — returning 1. Neither label described its query, and `Varianti` was never embedding search: `pgvector` is not even available in the `mema-postgres` image.

## What changed

Three switches, verified against the live 4504-row corpus:

| Corrispondenza | Granularità | Query | `ago` |
|---|---|---|---|
| Esatta | Parola intera | word-boundary regex, case+accent-insensitive | 1 |
| Esatta | Stringa | substring, case+accent-insensitive | 97 |
| Varianti | *locked to Parola intera* | Italian FTS, stemmed, ranked | 1 |

**Ambito** (`Solo titolo` / `Tutto il testo`) applies to all three. Result sets are now monotonic: `Esatta+Parola intera ⊆ Varianti ⊆ Esatta+Stringa`.

`Varianti` is morphological, not semantic — `guerra` ≡ `guerre` — and the UI hint says so. Granularità is disabled there because a tsvector is tokenized and has no substring notion.

## Migration (already applied to the live DB)

- `cop_norm()` — folds case, accents, and the two apostrophe forms the corpus mixes (468 ASCII vs 41 U+2019). `perche` now finds *Perché no*; `c'e` finds `nell’emergenza`.
- `caption_vector` — caption-only tsvector. `search_vector` blends caption and kicker, so it cannot answer a title-only query.

Must run as the `editions` owner (`isagog`, not `copertine_app` — `setup_db.sql`'s `ALTER SCHEMA` left the table owned by the superuser that created it; now fixed for fresh installs).

## Bugs fixed along the way

- **Paging dropped the search.** Browse and search had separate fetch paths and `PaginationControls` called the browse one — page 2 of a search silently returned the unfiltered list, still labelled a search result.
- **Sorting sorted one page.** It reordered only the 30 loaded rows, so "Titolo" over 4504 records was meaningless. Now server-side, with `id` as tiebreaker so OFFSET paging over ties doesn't duplicate or skip.
- A literal `%` or `_` in the needle acted as an ILIKE wildcard and matched all 4504 rows.
- Regex metacharacters raised `invalid regular expression`.
- `offset=abc` reached Postgres as `OFFSET 'NaN'` → 500.
- Highlighting was accent-sensitive (`perche` marked nothing on *Perché*) and substring-based regardless of mode.
- **Build was broken**: nothing pinned pnpm, so `corepack` resolved to pnpm 11, which `node:20-alpine`'s corepack cannot load. Pinned to `pnpm@10.34.5`.

## Verification

- 27 highlight assertions — accent/apostrophe folding, regex metacharacters, surrogate pairs, boundaries. **Caught a real bug**: the fold index map advanced per code *point* while the string grew per code *unit*, so any emoji would have shifted every later highlight.
- 9 serialisation assertions covering the paging fix.
- Full switch matrix + injection inputs against the live API, then re-verified on production after deploy.
- `tsc`, `next lint`, `next build` clean.

**Not verified:** client-side interactions (toggle → lock, page-2 click, sort headers). No browser automation available on the build host.

**Note:** this is already deployed — production is running this branch as `copfront:0.3.0`. Rollback point is tagged `copfront:0.3.0-pre-search`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)