### PR TITLE
fix(scraper): stop logging Monday's absent edition as an error

### DIFF
--- a/backend/src/sd2.py
+++ b/backend/src/sd2.py
@@ -25,6 +25,12 @@ HTTP_OK = 200
 # calendar days, not UTC calendar days.
 ROME_TZ = ZoneInfo("Europe/Rome")
 
+# datetime.weekday() index for Monday, the one weekday il manifesto does not
+# publish. The archive still holds 466 Monday editions, but they are historical
+# and taper off: the last one is 2024-06-10, and they were already sporadic for
+# a year before that. Forward-looking runs can treat Monday as always empty.
+MONDAY = 0
+
 
 class ScraperError(Exception):
     """Base exception for scraper errors."""
@@ -239,8 +245,22 @@ class DirectusManifestoScraper:
                 article = self._fetch_copertina_for_date(date)
                 if article:
                     self._process_copertina(article, date)
+                elif date.weekday() == MONDAY:
+                    # il manifesto does not publish on Mondays, so this is the
+                    # expected outcome roughly once per run — the default
+                    # lookback spans 3 days and therefore covers a Monday every
+                    # week. Logging it as an error made a routine weekly
+                    # non-event look like a failure.
+                    self.logger.info(f"No edition on Monday {date_str} (not published)")
                 else:
-                    self.logger.error(f"No copertina found for date: {date_str}")
+                    # A gap on any other day is NOT routine: it means Directus
+                    # has no cover for a day that should have one — a genuinely
+                    # missed edition, an upstream publishing delay, or a change
+                    # in the article metadata this query filters on. Warning
+                    # rather than error because the run itself succeeded and the
+                    # next one retries this date anyway (the lookback re-fetches
+                    # and the upsert is idempotent).
+                    self.logger.warning(f"No copertina found for date: {date_str}")
             except Exception:
                 self.logger.exception(f"Failed to process copertina for {date_str}")
                 continue


### PR DESCRIPTION
il manifesto does not publish on Mondays, so a missing Monday cover is the expected outcome, not a fault. The default lookback is 3 days, so **every week's runs cross a Monday** and emit an `ERROR` for it:

```
ERROR - No copertina found for date: 2026-08-10
```

Routine noise that would read as a weekly failure to anyone adding log alerting later.

## Change

| Case | Before | After |
|---|---|---|
| Monday (not published) | `ERROR` | `INFO` |
| Any other day | `ERROR` | `WARNING` |

## Why not blanket-INFO

Downgrading *every* miss would also silence the ones worth acting on. A gap on a publishing day means a genuinely missed edition, an upstream publishing delay, or a change in the article metadata the Directus query filters on — all things you'd want to see. `WARNING` rather than `ERROR` because the run itself succeeded and the next one retries the date anyway: the lookback re-fetches and the upsert is keyed on `edition_id`, so it self-heals.

Silencing everything would be the same defect as the current noise, only inverted.

## Is Monday really always empty?

Going forward, yes. The archive holds 466 Monday editions, but they are historical and taper off — verified against production:

```
last Monday editions: 2024-06-10, 2023-04-24, 2023-04-03, 2023-02-13, 2022-12-05
```

The most recent is over two years old and they were already sporadic for a year before that. Other weekdays sit at ~675 editions each.

## Verification

- `ruff check` passes
- Branch selection confirmed by weekday: `2026-08-10`/`2026-08-17` (Mondays) → INFO; `2026-08-11`/`2026-08-12` → WARNING

Next Monday in the lookback window is **2026-08-17**, which is when this first takes effect in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)